### PR TITLE
feat: implement login and queue preview flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,8 +43,11 @@ function App() {
   }
 
   function handleLeave() {
-    socket.emit('lobby:leave');
-    setCurrentPage('queue-preview');
+    if (user) {
+      socket.emit('lobby:leave');
+      setLobby({});
+      setCurrentPage('queue-preview');
+    }
   }
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,11 @@ function App() {
     }
   }
 
+  function handleLeave() {
+    socket.emit('lobby:leave');
+    setCurrentPage('queue-preview');
+  }
+
   useEffect(() => {
     socket.on('lobby:list', setLobby);
     socket.on('lobby:preview', setPreviewInfo);
@@ -59,7 +64,7 @@ function App() {
       return <Login onLogin={handleLogin} />;
     case 'lobby':
       return (
-        <Lobby athletes={athletes} court={court} nextGameDate={nextGameDate} />
+        <Lobby athletes={athletes} court={court} nextGameDate={nextGameDate} onLeave={handleLeave} />
       );
     case 'queue-preview':
       return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,9 +17,11 @@ const socket = io(URL, { autoConnect: false });
 socket.connect();
 
 function App() {
-  const [currentPage, setCurrentPage] = useState<Pages>('lobby');
+  const [currentPage, setCurrentPage] = useState<Pages>('login');
   const [{ athletes, court, nextGameDate }, setLobby] = useState<LobbyType>({});
+  const [previewInfo, setPreviewInfo] = useState<{ queueSize: number; nextGameDate: string } | null>(null);
   const [nextGame, setNextGame] = useState<Athlete[] | undefined>(undefined);
+  const [user, setUser] = useState<Omit<Athlete, 'id'> | null>(null);
 
   function handleNextGame(game: Athlete[]) {
     setNextGame(game);
@@ -28,25 +30,45 @@ function App() {
     }
   }
 
+  function handleLogin(data: Omit<Athlete, 'id'>) {
+    setUser(data);
+    setCurrentPage('queue-preview');
+  }
+
+  function handleJoinQueue() {
+    if (user) {
+      socket.emit('lobby:join', user);
+      setCurrentPage('lobby');
+    }
+  }
+
   useEffect(() => {
     socket.on('lobby:list', setLobby);
+    socket.on('lobby:preview', setPreviewInfo);
     socket.on('court:next-game', handleNextGame);
 
     return () => {
       socket.off('lobby:list', setLobby);
+      socket.off('lobby:preview', setPreviewInfo);
       socket.off('court:next-game', handleNextGame);
     };
   }, []);
 
   switch (currentPage) {
     case 'login':
-      return <Login />;
+      return <Login onLogin={handleLogin} />;
     case 'lobby':
       return (
         <Lobby athletes={athletes} court={court} nextGameDate={nextGameDate} />
       );
     case 'queue-preview':
-      return <QueuePreview />;
+      return (
+        <QueuePreview
+          queueSize={athletes ? athletes.length : (previewInfo?.queueSize ?? 0)}
+          nextGameDate={nextGameDate || previewInfo?.nextGameDate}
+          onJoin={handleJoinQueue}
+        />
+      );
     case 'your-turn':
       return <YourTurn game={nextGame} />;
     default:

--- a/src/pages/Lobby/Lobby.tsx
+++ b/src/pages/Lobby/Lobby.tsx
@@ -4,11 +4,15 @@ import { QueueSection } from './components/QueueSection/QueueSection';
 import { CourtsSection } from './components/CourtsSection';
 import { Container } from './styles';
 
-export function Lobby({ athletes, court, nextGameDate }: LobbyType) {
+interface LobbyProps extends LobbyType {
+  onLeave: () => void;
+}
+
+export function Lobby({ athletes, court, nextGameDate, onLeave }: LobbyProps) {
   return (
     <Container>
       <CourtsSection court={court ?? []} />
-      <QueueSection athletes={athletes} nextGameDate={nextGameDate} />
+      <QueueSection athletes={athletes} nextGameDate={nextGameDate} onLeave={onLeave} />
     </Container>
   );
 }

--- a/src/pages/Lobby/components/QueueSection/QueueSection.tsx
+++ b/src/pages/Lobby/components/QueueSection/QueueSection.tsx
@@ -12,6 +12,7 @@ import { QueueDisclaimer } from './QueueDisclaimer';
 export function QueueSection({
   athletes = [],
   nextGameDate,
+  onLeave,
 }: QueueSectionProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
@@ -43,7 +44,7 @@ export function QueueSection({
           subtitle="Você perderá a sua posição atual, mas poderá entrar novamente na
               fila quando quiser."
           actions={[
-            { label: 'Sair da fila', onClick: () => setIsDialogOpen(false) },
+            { label: 'Sair da fila', onClick: onLeave },
             {
               label: 'Voltar',
               onClick: () => setIsDialogOpen(false),

--- a/src/pages/Lobby/components/QueueSection/QueueSection.tsx
+++ b/src/pages/Lobby/components/QueueSection/QueueSection.tsx
@@ -44,7 +44,7 @@ export function QueueSection({
           subtitle="Você perderá a sua posição atual, mas poderá entrar novamente na
               fila quando quiser."
           actions={[
-            { label: 'Sair da fila', onClick: () => { setIsDialogOpen(false); onLeave(); } },
+            { label: 'Sair da fila', onClick: () => { setIsDialogOpen(false); onLeave?.(); } },
             {
               label: 'Voltar',
               onClick: () => setIsDialogOpen(false),

--- a/src/pages/Lobby/components/QueueSection/QueueSection.tsx
+++ b/src/pages/Lobby/components/QueueSection/QueueSection.tsx
@@ -44,7 +44,7 @@ export function QueueSection({
           subtitle="Você perderá a sua posição atual, mas poderá entrar novamente na
               fila quando quiser."
           actions={[
-            { label: 'Sair da fila', onClick: onLeave },
+            { label: 'Sair da fila', onClick: () => { setIsDialogOpen(false); onLeave(); } },
             {
               label: 'Voltar',
               onClick: () => setIsDialogOpen(false),

--- a/src/pages/Lobby/components/QueueSection/types.ts
+++ b/src/pages/Lobby/components/QueueSection/types.ts
@@ -3,5 +3,5 @@ import { Athlete } from '@shared/types';
 export interface QueueSectionProps {
   athletes?: Athlete[];
   nextGameDate?: string;
-  onLeave: () => void;
+  onLeave?: () => void;
 }

--- a/src/pages/Lobby/components/QueueSection/types.ts
+++ b/src/pages/Lobby/components/QueueSection/types.ts
@@ -3,4 +3,5 @@ import { Athlete } from '@shared/types';
 export interface QueueSectionProps {
   athletes?: Athlete[];
   nextGameDate?: string;
+  onLeave: () => void;
 }

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -5,18 +5,22 @@ import { Input } from '@shared/components/Input';
 
 import { Container, Form, InputsWrapper, Title } from './styles';
 import { GenderSelector } from './components/GenderSelector';
+import { Athlete } from '@shared/types';
 
-export function Login() {
+interface LoginProps {
+  onLogin: (data: Omit<Athlete, 'id'>) => void;
+}
+
+export function Login({ onLogin }: LoginProps) {
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const form = event.currentTarget;
     const formData = new FormData(form);
 
-    const data = Object.fromEntries(formData.entries());
+    const data = Object.fromEntries(formData.entries()) as Omit<Athlete, 'id'>;
 
-    // TODO - properly handle form data
-    console.log(data);
+    onLogin(data);
   };
   return (
     <Container>

--- a/src/pages/QueuePreview/QueuePreview.tsx
+++ b/src/pages/QueuePreview/QueuePreview.tsx
@@ -11,8 +11,18 @@ import {
   PreviewContainer,
 } from './styles';
 
-export function QueuePreview() {
-  const isQueueEmpty = false;
+interface QueuePreviewProps {
+  queueSize: number;
+  nextGameDate?: string;
+  onJoin: () => void;
+}
+
+export function QueuePreview({ queueSize, nextGameDate, onJoin }: QueuePreviewProps) {
+  const isQueueEmpty = queueSize === 0;
+
+  const minutesToWait = nextGameDate
+    ? Math.max(0, Math.round((new Date(nextGameDate).getTime() - Date.now()) / 60000))
+    : 0;
 
   return (
     <Container>
@@ -42,20 +52,20 @@ export function QueuePreview() {
               </CenteredText>
               <PreviewContainer>
                 <PreviewItem
-                  number={45}
+                  number={minutesToWait}
                   title="minutos"
                   description="Tempo estimado de espera até o seu próximo jogo"
                 />
 
                 <PreviewItem
-                  number={12}
+                  number={queueSize}
                   title="atletas"
                   description="Esperando para jogar"
                 />
               </PreviewContainer>
             </>
           )}
-          <Button label="Entrar na fila" onClick={() => {}} />
+          <Button label="Entrar na fila" onClick={onJoin} />
         </Content>
       </Card>
     </Container>


### PR DESCRIPTION
This pull request introduces a user authentication and queue preview flow to the application, improving the onboarding experience for users before they join the lobby. The main changes include adding a login page that collects user information, a queue preview page that shows estimated wait time and queue size, and the necessary state and socket event handling to support these features.

**User authentication and onboarding flow:**

* The initial page is now set to `'login'`, and a new `handleLogin` function is introduced to store user data and transition to the queue preview page upon login. (`src/App.tsx`, [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L20-R24) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R33-R71)
* The `Login` component is updated to accept an `onLogin` prop and call it with the submitted user data, replacing the previous placeholder logic. (`src/pages/Login/Login.tsx`, [src/pages/Login/Login.tsxR8-R23](diffhunk://#diff-ab454050cfbb90b5889f7045c75f12697add21c0570842147850bc7227e1c0adR8-R23))

**Queue preview and joining logic:**

* A `QueuePreview` page is added, which receives the current queue size and estimated wait time as props, and provides an "Entrar na fila" button that triggers joining the queue. (`src/pages/QueuePreview/QueuePreview.tsx`, [[1]](diffhunk://#diff-6ffbda84f4d041e1316fad5d94ba6fc63bea35bdaec810bf7bc517774e36b47eL14-R25) [[2]](diffhunk://#diff-6ffbda84f4d041e1316fad5d94ba6fc63bea35bdaec810bf7bc517774e36b47eL45-R68)
* The main `App` component manages the state for `previewInfo` (queue size and next game date) and `user`, and handles socket events to update these values and transition between pages. (`src/App.tsx`, [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L20-R24) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R33-R71)
* The "Entrar na fila" button now emits a `lobby:join` socket event with the user data and transitions to the lobby page. (`src/App.tsx`, [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R33-R71); `src/pages/QueuePreview/QueuePreview.tsx`, [[2]](diffhunk://#diff-6ffbda84f4d041e1316fad5d94ba6fc63bea35bdaec810bf7bc517774e36b47eL45-R68)